### PR TITLE
Incorrect title for Redstone Card recipe

### DIFF
--- a/src/main/resources/data/laserio/patchouli_books/laseriobook/en_us/entries/card_redstone.json
+++ b/src/main/resources/data/laserio/patchouli_books/laseriobook/en_us/entries/card_redstone.json
@@ -22,7 +22,7 @@
     },
     {
       "type": "patchouli:crafting",
-      "title": "Energy Card",
+      "title": "Redstone Card",
       "recipe": "laserio:card_redstone"
     }
   ]


### PR DESCRIPTION
The title of Redstone Card in the LaserIO book is incorrect.

fixes: https://github.com/Direwolf20-MC/LaserIO/issues/70