### PR TITLE
Cards disappear when inventory full

### DIFF
--- a/src/main/java/com/direwolf20/laserio/common/containers/CardHolderContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardHolderContainer.java
@@ -166,7 +166,10 @@ public class CardHolderContainer extends AbstractContainerMenu {
             //itemstack.setCount(1);
             //If its one of the 20 slots at the top try to move it into your inventory
             if (index < SLOTS) {
-                if (!this.moveItemStackTo(stack.split(1), SLOTS, 36 + SLOTS, true)) {
+                if (playerIn.getInventory().getFreeSlot() != -1) {
+                    // moveItemStackTo() always moves the item, no matter the return value. fixes #87
+                    this.moveItemStackTo(stack.split(1), SLOTS, 36 + SLOTS, true);
+                } else {
                     return ItemStack.EMPTY;
                 }
                 slot.onQuickCraft(stack, itemstack);


### PR DESCRIPTION
Moving a card from the cardholder to an inventory that is full, voids the cards. The reason is the call to moveItemStackTo() method always moves the ItemStack, no matter the return value.

Fix by adding a check if there is room in the inventory

Fixes https://github.com/Direwolf20-MC/LaserIO/issues/87 and possibly https://github.com/Direwolf20-MC/LaserIO/issues/76