### PR TITLE
Show target block in laser node and cards

### DIFF
--- a/src/generated/resources/assets/laserio/lang/en_us.json
+++ b/src/generated/resources/assets/laserio/lang/en_us.json
@@ -49,6 +49,7 @@
   "screen.laserio.exact": "Exact",
   "screen.laserio.extract": "Extract",
   "screen.laserio.extractamt": "Transfer Amount",
+  "screen.laserio.facing": "Facing",
   "screen.laserio.false": "False",
   "screen.laserio.high": "High",
   "screen.laserio.ignored": "Ignored",

--- a/src/main/java/com/direwolf20/laserio/client/renderer/RenderUtils.java
+++ b/src/main/java/com/direwolf20/laserio/client/renderer/RenderUtils.java
@@ -25,12 +25,29 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 
 import java.awt.*;
+import java.util.EnumMap;
 import java.util.Queue;
 import java.util.Set;
 
 import static com.direwolf20.laserio.util.MiscTools.findOffset;
 
 public class RenderUtils {
+    private static EnumMap<BaseCard.CardType, Color> cardTypeColors = new EnumMap<BaseCard.CardType, Color>(BaseCard.CardType.class);
+    
+    static {
+        cardTypeColors.put(BaseCard.CardType.ITEM, new Color(0f, 1f, 0f));
+        cardTypeColors.put(BaseCard.CardType.FLUID, new Color(0f, 0f, 1f));
+        cardTypeColors.put(BaseCard.CardType.ENERGY, new Color(1f, 1f, 0f));
+        cardTypeColors.put(BaseCard.CardType.REDSTONE, new Color(1f, 0f, 0f));
+    }
+
+    public static Color getColor(BaseCard.CardType cardType){
+        Color color = cardTypeColors.get(cardType);
+        if (color == null)
+            return Color.BLACK;
+        return color;
+    }
+
     public static void render(Matrix4f matrix, VertexConsumer builder, BlockPos pos, Color color, float scale) {
         float red = color.getRed() / 255f, green = color.getGreen() / 255f, blue = color.getBlue() / 255f, alpha = .5f;
 

--- a/src/main/java/com/direwolf20/laserio/client/screens/AbstractCardScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/AbstractCardScreen.java
@@ -1,0 +1,75 @@
+package com.direwolf20.laserio.client.screens;
+
+import com.direwolf20.laserio.client.renderer.RenderUtils;
+import com.direwolf20.laserio.common.blocks.LaserNode;
+import com.direwolf20.laserio.common.containers.AbstractCardContainer;
+import com.direwolf20.laserio.common.items.cards.BaseCard;
+import com.direwolf20.laserio.util.MiscTools;
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Widget;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractCardScreen<T extends AbstractCardContainer> extends AbstractContainerScreen<T>  {
+
+    public final static String ReturnButton = "return";
+
+    public final BaseCard.CardType CardType;
+
+    protected final T baseContainer;
+    protected final ItemStack card;
+
+    protected Map<String, Button> buttons = new HashMap<>();
+    public final List<Widget> backgroundRenderables = new ArrayList<>();
+
+    public AbstractCardScreen(T container, Inventory pPlayerInventory, Component pTitle) {
+        super(container, pPlayerInventory, pTitle);
+        this.baseContainer = container;
+        card = container.cardItem;
+        Item cardItem = card.getItem();
+        BaseCard baseCard = cardItem instanceof BaseCard ? (BaseCard) cardItem : null;
+        CardType = baseCard != null ? baseCard.getCardType() : BaseCard.CardType.MISSING;
+    }
+
+    public abstract void openNode();
+
+    public void addCommonWidgets() {
+        if (baseContainer.direction == -1)
+            return;
+        buttons.put(ReturnButton, new Button(getGuiLeft() - 25, getGuiTop() + 1, 25, 20, Component.literal("<--"), (button) -> {
+            openNode();
+        }));
+    }
+
+    protected void renderTooltip(PoseStack pPoseStack, int mouseX, int mouseY) {
+        super.renderTooltip(pPoseStack, mouseX, mouseY);
+        Button returnButton = buttons.get(ReturnButton);
+        if (MiscTools.inBounds(returnButton, mouseX, mouseY)) {
+            this.renderTooltip(pPoseStack, Component.translatable(LaserNode.SCREEN_LASERNODE), mouseX, mouseY);
+        }
+    }
+
+    @Override
+    public void render(PoseStack matrixStack, int mouseX, int mouseY, float partialTicks) {
+        super.render(matrixStack, mouseX, mouseY, partialTicks);   
+    }
+
+    @Override
+    protected void renderBg(PoseStack matrixStack, float partialTicks, int mouseX, int mouseY) {
+        for(Widget widget : backgroundRenderables) {
+            widget.render(matrixStack, mouseX, mouseY, partialTicks);
+        }
+    }
+    
+}

--- a/src/main/java/com/direwolf20/laserio/client/screens/AbstractCardScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/AbstractCardScreen.java
@@ -1,12 +1,14 @@
 package com.direwolf20.laserio.client.screens;
 
 import com.direwolf20.laserio.client.renderer.RenderUtils;
+import com.direwolf20.laserio.client.screens.widgets.SidePanel;
 import com.direwolf20.laserio.common.blocks.LaserNode;
 import com.direwolf20.laserio.common.containers.AbstractCardContainer;
 import com.direwolf20.laserio.common.items.cards.BaseCard;
 import com.direwolf20.laserio.util.MiscTools;
 import com.mojang.blaze3d.vertex.PoseStack;
 
+import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Widget;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
@@ -24,14 +26,18 @@ import java.util.Map;
 public abstract class AbstractCardScreen<T extends AbstractCardContainer> extends AbstractContainerScreen<T>  {
 
     public final static String ReturnButton = "return";
-
+    public final static String SideButton = "side";
+    public final static String HeaderPanel = "header";
+    
     public final BaseCard.CardType CardType;
 
     protected final T baseContainer;
     protected final ItemStack card;
 
     protected Map<String, Button> buttons = new HashMap<>();
-    public final List<Widget> backgroundRenderables = new ArrayList<>();
+    public final Map<String, AbstractWidget> widgets = new HashMap<>();
+    public final List<AbstractWidget> backgroundRenderables = new ArrayList<>();
+    private String sideName;
 
     public AbstractCardScreen(T container, Inventory pPlayerInventory, Component pTitle) {
         super(container, pPlayerInventory, pTitle);
@@ -50,6 +56,27 @@ public abstract class AbstractCardScreen<T extends AbstractCardContainer> extend
         buttons.put(ReturnButton, new Button(getGuiLeft() - 25, getGuiTop() + 1, 25, 20, Component.literal("<--"), (button) -> {
             openNode();
         }));
+
+        var sideCmp = LaserNodeScreen.sides[baseContainer.direction];
+        sideName = sideCmp.getString();
+        ItemStack blockItemStack = null;
+        var stateFaced = baseContainer.getBlockStateFaced();
+        if (stateFaced != null){
+            var blockFaced = stateFaced.getBlock();
+            if (blockFaced != null){
+                sideName += ": " + blockFaced.getName().getString();
+                var blockItem = blockFaced.asItem();
+                if (blockItem != null)
+                    blockItemStack = new ItemStack(blockItem);
+            }
+        }
+        var sideText = sideCmp;
+        int x = getGuiLeft() - 37, y = getGuiTop() + 26;
+        int w = 40, h = 40;
+        Color color = RenderUtils.getColor(CardType);
+        var sideWidget = new SidePanel(x, y, w, h, sideText, color, blockItemStack, this.itemRenderer);
+        widgets.put(SideButton, sideWidget);
+        addRenderableOnly(sideWidget);
     }
 
     protected void renderTooltip(PoseStack pPoseStack, int mouseX, int mouseY) {
@@ -57,6 +84,14 @@ public abstract class AbstractCardScreen<T extends AbstractCardContainer> extend
         Button returnButton = buttons.get(ReturnButton);
         if (MiscTools.inBounds(returnButton, mouseX, mouseY)) {
             this.renderTooltip(pPoseStack, Component.translatable(LaserNode.SCREEN_LASERNODE), mouseX, mouseY);
+        }
+        AbstractWidget sideWidget = widgets.get(SideButton);
+        if (MiscTools.inBounds(sideWidget, mouseX, mouseY)) {
+            ArrayList<Component> tooltips = new ArrayList<Component>();
+            //tooltips.add(LaserNodeScreen.sides[baseContainer.direction]);
+            //tooltips.add(sideWidget.getMessage());
+            tooltips.add(Component.literal(sideName));
+            this.renderComponentTooltip(pPoseStack, tooltips, mouseX, mouseY);
         }
     }
 

--- a/src/main/java/com/direwolf20/laserio/client/screens/CardEnergyScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/CardEnergyScreen.java
@@ -20,7 +20,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -28,12 +27,10 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
-import net.minecraft.world.item.ItemStack;
 
-import java.util.HashMap;
 import java.util.Map;
 
-public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContainer> {
+public class CardEnergyScreen extends AbstractCardScreen<CardEnergyContainer> {
     private final ResourceLocation GUI = new ResourceLocation(LaserIO.MODID, "textures/gui/energycard.png");
 
     protected final CardEnergyContainer container;
@@ -49,8 +46,6 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
     protected boolean currentRegulate;
     protected int currentExtractLimitPercent;
     protected int currentInsertLimitPercent;
-    protected final ItemStack card;
-    protected Map<String, Button> buttons = new HashMap<>();
     protected byte currentRedstoneMode;
 
     protected final String[] sneakyNames = {
@@ -66,7 +61,6 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
     public CardEnergyScreen(CardEnergyContainer container, Inventory inv, Component name) {
         super(container, inv, name);
         this.container = container;
-        this.card = container.cardItem;
     }
 
     @Override
@@ -243,6 +237,7 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
         addModeButton();
         addRedstoneButton();
         addRedstoneChannelButton();
+        addCommonWidgets();
 
         buttons.put("channel", new ChannelButton(getGuiLeft() + 5, getGuiTop() + 65, 16, 16, currentChannel, (button) -> {
             currentChannel = BaseCard.nextChannel(card);
@@ -261,12 +256,6 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
             currentSneaky = BaseCard.nextSneaky(card);
             ((ToggleButton) button).setTexturePosition(currentSneaky + 1);
         }));
-
-        if (container.direction != -1) {
-            buttons.put("return", new Button(getGuiLeft() - 25, getGuiTop() + 1, 25, 20, Component.literal("<--"), (button) -> {
-                openNode();
-            }));
-        }
 
         for (Map.Entry<String, Button> button : buttons.entrySet()) {
             addRenderableWidget(button.getValue());
@@ -437,6 +426,7 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
 
     @Override
     protected void renderBg(PoseStack matrixStack, float partialTicks, int mouseX, int mouseY) {
+        super.renderBg(matrixStack, partialTicks, mouseX, mouseY);
         RenderSystem.setShaderTexture(0, GUI);
         int relX = (this.width - this.imageWidth) / 2;
         int relY = (this.height - this.imageHeight) / 2;
@@ -503,6 +493,7 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
         PacketHandler.sendToServer(new PacketUpdateCard(currentMode, currentChannel, currentEnergyExtractAmt, currentPriority, currentSneaky, (short) currentTicks, currentExact, currentRegulate, (byte) currentRoundRobin, currentExtractLimitPercent, currentInsertLimitPercent, currentRedstoneMode, currentRedstoneChannel, false));
     }
 
+    @Override
     public void openNode() {
         saveSettings();
         PacketHandler.sendToServer(new PacketOpenNode(container.sourceContainer, container.direction));

--- a/src/main/java/com/direwolf20/laserio/client/screens/CardItemScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/CardItemScreen.java
@@ -22,7 +22,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.network.chat.Component;
@@ -35,10 +34,9 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 
-import java.util.HashMap;
 import java.util.Map;
 
-public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
+public class CardItemScreen extends AbstractCardScreen<CardItemContainer> {
     private final ResourceLocation GUI = new ResourceLocation(LaserIO.MODID, "textures/gui/itemcard.png");
 
     protected final CardItemContainer container;
@@ -58,9 +56,7 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
     protected boolean showFilter;
     protected boolean showAllow;
     protected boolean showNBT;
-    protected final ItemStack card;
     public ItemStack filter;
-    protected Map<String, Button> buttons = new HashMap<>();
     protected byte currentRedstoneMode;
 
     protected final String[] sneakyNames = {
@@ -76,7 +72,6 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
     public CardItemScreen(CardItemContainer container, Inventory inv, Component name) {
         super(container, inv, name);
         this.container = container;
-        this.card = container.cardItem;
         filter = container.slots.get(0).getItem();
     }
 
@@ -329,6 +324,7 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
         addModeButton();
         addRedstoneButton();
         addRedstoneChannelButton();
+        addCommonWidgets();
 
         buttons.put("channel", new ChannelButton(getGuiLeft() + 5, getGuiTop() + 65, 16, 16, currentChannel, (button) -> {
             currentChannel = BaseCard.nextChannel(card);
@@ -347,12 +343,6 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
             currentSneaky = BaseCard.nextSneaky(card);
             ((ToggleButton) button).setTexturePosition(currentSneaky + 1);
         }));
-
-        if (container.direction != -1) {
-            buttons.put("return", new Button(getGuiLeft() - 25, getGuiTop() + 1, 25, 20, Component.literal("<--"), (button) -> {
-                openNode();
-            }));
-        }
 
         for (Map.Entry<String, Button> button : buttons.entrySet()) {
             addRenderableWidget(button.getValue());
@@ -580,6 +570,7 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
 
     @Override
     protected void renderBg(PoseStack matrixStack, float partialTicks, int mouseX, int mouseY) {
+        super.renderBg(matrixStack, partialTicks, mouseX, mouseY);
         RenderSystem.setShaderTexture(0, GUI);
         int relX = (this.width - this.imageWidth) / 2;
         int relY = (this.height - this.imageHeight) / 2;
@@ -664,6 +655,7 @@ public class CardItemScreen extends AbstractContainerScreen<CardItemContainer> {
         return true;
     }
 
+    @Override
     public void openNode() {
         saveSettings();
         PacketHandler.sendToServer(new PacketOpenNode(container.sourceContainer, container.direction));

--- a/src/main/java/com/direwolf20/laserio/client/screens/CardRedstoneScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/CardRedstoneScreen.java
@@ -14,32 +14,26 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.item.ItemStack;
 
-import java.util.HashMap;
 import java.util.Map;
 
-public class CardRedstoneScreen extends AbstractContainerScreen<CardRedstoneContainer> {
+public class CardRedstoneScreen extends AbstractCardScreen<CardRedstoneContainer> {
     private final ResourceLocation GUI = new ResourceLocation(LaserIO.MODID, "textures/gui/redstonecard.png");
 
     protected final CardRedstoneContainer container;
     protected byte currentMode;
     protected byte currentRedstoneChannel;
     protected boolean currentStrong;
-    protected final ItemStack card;
-    protected Map<String, Button> buttons = new HashMap<>();
 
     public CardRedstoneScreen(CardRedstoneContainer container, Inventory inv, Component name) {
         super(container, inv, name);
         this.container = container;
-        this.card = container.cardItem;
     }
 
     @Override
@@ -106,12 +100,7 @@ public class CardRedstoneScreen extends AbstractContainerScreen<CardRedstoneCont
         addModeButton();
         addChannelButton();
         addStrongButton();
-
-        if (container.direction != -1) {
-            buttons.put("return", new Button(getGuiLeft() - 25, getGuiTop() + 1, 25, 20, Component.literal("<--"), (button) -> {
-                openNode();
-            }));
-        }
+        addCommonWidgets();
 
         for (Map.Entry<String, Button> button : buttons.entrySet()) {
             addRenderableWidget(button.getValue());
@@ -146,6 +135,7 @@ public class CardRedstoneScreen extends AbstractContainerScreen<CardRedstoneCont
 
     @Override
     protected void renderBg(PoseStack matrixStack, float partialTicks, int mouseX, int mouseY) {
+        super.renderBg(matrixStack, partialTicks, mouseX, mouseY);
         RenderSystem.setShaderTexture(0, GUI);
         int relX = (this.width - this.imageWidth) / 2;
         int relY = (this.height - this.imageHeight) / 2;
@@ -193,6 +183,7 @@ public class CardRedstoneScreen extends AbstractContainerScreen<CardRedstoneCont
         PacketHandler.sendToServer(new PacketUpdateRedstoneCard(currentMode, currentRedstoneChannel, currentStrong));
     }
 
+    @Override
     public void openNode() {
         saveSettings();
         PacketHandler.sendToServer(new PacketOpenNode(container.sourceContainer, container.direction));

--- a/src/main/java/com/direwolf20/laserio/client/screens/LaserNodeScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/LaserNodeScreen.java
@@ -31,7 +31,7 @@ public class LaserNodeScreen extends AbstractContainerScreen<LaserNodeContainer>
     private final ResourceLocation GUI = new ResourceLocation(LaserIO.MODID, "textures/gui/laser_node.png");
     protected final LaserNodeContainer container;
     private boolean showCardHolderUI;
-    private final MutableComponent[] sides = {
+    public static final MutableComponent[] sides = {
             Component.translatable("screen.laserio.down"),
             Component.translatable("screen.laserio.up"),
             Component.translatable("screen.laserio.north"),

--- a/src/main/java/com/direwolf20/laserio/client/screens/LaserNodeScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/LaserNodeScreen.java
@@ -49,12 +49,37 @@ public class LaserNodeScreen extends AbstractContainerScreen<LaserNodeContainer>
             new Vec2i(146, 4)
     };
 
+    private ItemStack facedBlockItemStack;
+    private Component facedBlockName;
+
+    private Component facing = Component.translatable("screen.laserio.facing");
+    private int xcr; // Center of column to right of inventory
+    private int xFaced; // X position of faced block
+    private int yFaced; // Y position of faced block
+
     public LaserNodeScreen(LaserNodeContainer container, Inventory inv, Component name) {
         super(container, inv, name);
         this.container = container;
         this.imageHeight = 181;
         showCardHolderUI = container.cardHolder.isEmpty();
         //this.imageWidth = 202;
+
+        //var sideCmp = LaserNodeScreen.sides[container.side];
+        //sideName = sideCmp.getString();
+        var stateFaced = container.getBlockStateFaced();
+        if (stateFaced != null){
+            var blockFaced = stateFaced.getBlock();
+            if (blockFaced != null){
+                facedBlockName = blockFaced.getName();
+                var blockItem = blockFaced.asItem();
+                if (blockItem != null)
+                facedBlockItemStack = new ItemStack(blockItem);
+            }
+        }
+        var invSize = 3 * 18;
+        xcr = imageWidth - (imageWidth - invSize)/4;
+        xFaced = xcr - 8;
+        yFaced = 36;
     }
 
     @Override
@@ -75,6 +100,8 @@ public class LaserNodeScreen extends AbstractContainerScreen<LaserNodeContainer>
         this.renderBackground(matrixStack);
         super.render(matrixStack, mouseX, mouseY, partialTicks);
         this.renderTooltip(matrixStack, mouseX, mouseY);
+        if (MiscTools.inBounds(getGuiLeft() + xFaced, getGuiTop() + yFaced, 16, 16, mouseX, mouseY))
+            renderTooltip(matrixStack, facedBlockName, mouseX, mouseY);
     }
 
     @Override
@@ -83,13 +110,27 @@ public class LaserNodeScreen extends AbstractContainerScreen<LaserNodeContainer>
         fill(matrixStack, tabs[container.side].x, tabs[container.side].y + 11, tabs[container.side].x + 2, tabs[container.side].y + 12, 0xFFFFFFFF);
         fill(matrixStack, tabs[container.side].x + 22, tabs[container.side].y + 11, tabs[container.side].x + 24, tabs[container.side].y + 12, 0xFFFFFFFF);
         matrixStack.pushPose();
-        font.draw(matrixStack, sides[container.side].getString(), imageWidth / 2 - font.width(sides[container.side].getString()) / 2, 20, Color.DARK_GRAY.getRGB());
+        int sideSize = font.width(sides[container.side].getString());
+        int sideX = imageWidth / 2 - sideSize / 2, sideY = 20;
+        font.draw(matrixStack, sides[container.side].getString(), sideX, sideY, Color.DARK_GRAY.getRGB());
         font.draw(matrixStack, "U", 15, 7, Color.DARK_GRAY.getRGB());
         font.draw(matrixStack, "D", 43, 7, Color.DARK_GRAY.getRGB());
         font.draw(matrixStack, "N", 71, 7, Color.DARK_GRAY.getRGB());
         font.draw(matrixStack, "S", 99, 7, Color.DARK_GRAY.getRGB());
         font.draw(matrixStack, "W", 128, 7, Color.DARK_GRAY.getRGB());
         font.draw(matrixStack, "E", 155, 7, Color.DARK_GRAY.getRGB());
+        if (this.facedBlockItemStack != null){
+            var isEmpty = facedBlockItemStack.isEmpty();
+            var textSize = font.width(facing);
+            font.draw(matrixStack, facing, xcr - textSize/2, 24, Color.DARK_GRAY.getRGB());
+            if (isEmpty){
+                var blockName = facedBlockName;
+                var nameSize = font.width(blockName);
+                font.draw(matrixStack, blockName, xcr - nameSize/2, yFaced, Color.DARK_GRAY.getRGB());
+            } else {
+                this.itemRenderer.renderAndDecorateFakeItem(this.facedBlockItemStack, xFaced, yFaced);    
+            }
+        }
         matrixStack.popPose();
     }
 

--- a/src/main/java/com/direwolf20/laserio/client/screens/widgets/Panel.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/widgets/Panel.java
@@ -1,0 +1,111 @@
+package com.direwolf20.laserio.client.screens.widgets;
+
+import java.awt.Color;
+import java.util.function.Consumer;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.narration.NarratedElementType;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.network.chat.Component;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+public class Panel extends AbstractWidget {
+    public static final Panel.OnTooltip NO_TOOLTIP = (p_93740_, p_93741_, p_93742_, p_93743_) -> {
+    };
+    protected final Panel.OnTooltip onTooltip;
+
+    public int outline = Color.BLACK.getRGB();
+    public int highLight = Color.WHITE.getRGB();
+    public int middle = Color.LIGHT_GRAY.getRGB();
+    public int shadow = Color.DARK_GRAY.getRGB();
+    public int background = Color.LIGHT_GRAY.getRGB();
+    public int style = 1;
+
+    public Panel(int pX, int pY, int pWidth, int pHeight, Component pMessage) {
+        this(pX, pY, pWidth, pHeight, pMessage, NO_TOOLTIP);
+    }
+
+    public Panel(int pX, int pY, int pWidth, int pHeight, Component pMessage, Panel.OnTooltip pOnTooltip) {
+        super(pX, pY, pWidth, pHeight, pMessage);
+        onTooltip = NO_TOOLTIP;
+    }
+
+    public void setColorsFromHighlight(Color color){
+        highLight = color.getRGB();
+        Color darker = color.darker();
+        middle = darker.getRGB();
+        background = middle;
+        Color darkerer = darker.darker();
+        shadow = darkerer.getRGB();
+        Color dank = darkerer.darker();
+        outline = dank.getRGB();
+    }
+
+    @Override
+    public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
+        if (!visible)
+            return;
+        isHovered = pMouseX >= x && pMouseY >= y && pMouseX < x + width && pMouseY < y + height;
+
+        if (style == 0){
+            int outerInset = 1;
+            int innerInset = 3;
+            fill(pPoseStack, x, y, x + width, y + height, outline);
+            fill(pPoseStack, x + outerInset, y + outerInset, x + width - innerInset, y + height - innerInset, highLight);
+            fill(pPoseStack, x + innerInset, y + innerInset, x + width - outerInset, y + height - outerInset, shadow);
+            fill(pPoseStack, x + innerInset, y + innerInset, x + width - innerInset, y + height - innerInset, background);
+        } else {
+            hLine(pPoseStack, x + 2, x + width - 4, y, outline);
+            hLine(pPoseStack, x + 3, x + width - 3, y + height - 1, outline);
+            vLine(pPoseStack, x, y + 1, y + height - 3, outline);
+            vLine(pPoseStack, x + width - 1, y + 2, y + height - 2, outline);
+            pixel(pPoseStack, x + width - 3, y + 1, outline);
+            pixel(pPoseStack, x + width - 2, y + 2, outline);
+            pixel(pPoseStack, x + 1, y + height - 3, outline);
+            pixel(pPoseStack, x + 2, y + height - 2, outline);
+            pixel(pPoseStack, x + 1, y + 1, outline);
+            pixel(pPoseStack, x + width - 2, y + height - 2, outline);
+
+            pixel(pPoseStack, x + width - 3, y + 2, middle);
+            pixel(pPoseStack, x + 2, y + height - 3, middle);
+
+            fill(pPoseStack, x + 2, y + 1, x + width - 3, y + 3, highLight);
+            fill(pPoseStack, x + 1, y + 2, x + 3, y + height - 3, highLight);
+            
+            fill(pPoseStack, x + 3, y + height - 3, x + width - 2, y + height - 1, shadow);
+            fill(pPoseStack, x + width - 3, y + 3, x + width - 1, y + height - 2, shadow);
+
+            fill(pPoseStack, x + 3, y + 3, x + width - 3, y + height - 3, background);
+
+            pixel(pPoseStack, x + 3, y + 3, highLight);
+            pixel(pPoseStack, x + width - 4, y + 3, middle);
+            pixel(pPoseStack, x + 3, y + height - 4, middle);
+            pixel(pPoseStack, x + width - 4, y + width - 4, shadow);
+        }
+    }
+
+    private void pixel(PoseStack pPoseStack, int x, int y, int color){
+        fill(pPoseStack, x, y, x + 1, y + 1, color);
+    }
+
+    @Override
+    public void updateNarration(NarrationElementOutput pNarrationElementOutput) {
+        this.defaultButtonNarrationText(pNarrationElementOutput);
+        this.onTooltip.narrateTooltip((p_168841_) -> {
+            pNarrationElementOutput.add(NarratedElementType.HINT, p_168841_);
+        });
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    public interface OnTooltip {
+       void onTooltip(Panel panel, PoseStack pPoseStack, int pMouseX, int pMouseY);
+ 
+       default void narrateTooltip(Consumer<Component> pContents) {
+       }
+    }
+    
+}

--- a/src/main/java/com/direwolf20/laserio/client/screens/widgets/SidePanel.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/widgets/SidePanel.java
@@ -1,0 +1,40 @@
+package com.direwolf20.laserio.client.screens.widgets;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
+import java.awt.Color;
+
+public class SidePanel extends Panel {
+
+    private Color color;
+    private ItemStack itemStack;
+    private ItemRenderer itemRenderer;
+
+    public SidePanel(int pX, int pY, int pWidth, int pHeight, Component pMessage, Color color, ItemStack itemStack,
+        ItemRenderer itemRenderer)
+    {
+        super(pX, pY, pWidth, pHeight, pMessage);
+        this.color = color;
+        this.itemStack = itemStack;
+        this.itemRenderer = itemRenderer;
+        setColorsFromHighlight(color);
+    }
+
+    @Override
+    public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
+        super.render(pPoseStack, pMouseX, pMouseY, pPartialTick);
+
+        var font = Minecraft.getInstance().font;
+        var text = getMessage().getString();
+        drawCenteredString(pPoseStack, font, text, x + width/2, y + 4, 0xffffff);
+
+        if (this.itemStack != null)
+            this.itemRenderer.renderAndDecorateFakeItem(this.itemStack, x + width/2 - 8, y + 18);
+    }
+    
+}

--- a/src/main/java/com/direwolf20/laserio/common/containers/AbstractCardContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/AbstractCardContainer.java
@@ -24,15 +24,6 @@ public abstract class AbstractCardContainer extends AbstractContainerMenu {
     public Player playerEntity;
     protected IItemHandler playerInventory;
 
-    public static final Direction[] DIRS = {
-        Direction.DOWN,
-        Direction.UP,
-        Direction.NORTH,
-        Direction.SOUTH,
-        Direction.WEST,
-        Direction.EAST,
-    };
-
     protected AbstractCardContainer(MenuType<?> pMenuType, int pContainerId, ItemStack cardItem) {
         super(pMenuType, pContainerId);
         this.cardItem = cardItem;
@@ -41,7 +32,7 @@ public abstract class AbstractCardContainer extends AbstractContainerMenu {
     public Direction getDirection(){
         if (direction == -1)
             return null;
-        return DIRS[direction];
+        return LaserNodeContainer.DIRS[direction];
     }
     
     public BlockEntity getBlockFaced(){

--- a/src/main/java/com/direwolf20/laserio/common/containers/AbstractCardContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/AbstractCardContainer.java
@@ -1,0 +1,18 @@
+package com.direwolf20.laserio.common.containers;
+
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.item.ItemStack;
+
+public abstract class AbstractCardContainer extends AbstractContainerMenu {
+
+    public final ItemStack cardItem;
+
+    public byte direction = -1;
+
+    protected AbstractCardContainer(MenuType<?> pMenuType, int pContainerId, ItemStack cardItem) {
+        super(pMenuType, pContainerId);
+        this.cardItem = cardItem;
+    }
+    
+}

--- a/src/main/java/com/direwolf20/laserio/common/containers/AbstractCardContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/AbstractCardContainer.java
@@ -1,18 +1,66 @@
 package com.direwolf20.laserio.common.containers;
 
+import com.direwolf20.laserio.common.blockentities.LaserNodeBE;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.items.IItemHandler;
 
 public abstract class AbstractCardContainer extends AbstractContainerMenu {
 
     public final ItemStack cardItem;
 
     public byte direction = -1;
+    public BlockPos sourceContainer = BlockPos.ZERO;
+    public Player playerEntity;
+    protected IItemHandler playerInventory;
+
+    public static final Direction[] DIRS = {
+        Direction.DOWN,
+        Direction.UP,
+        Direction.NORTH,
+        Direction.SOUTH,
+        Direction.WEST,
+        Direction.EAST,
+    };
 
     protected AbstractCardContainer(MenuType<?> pMenuType, int pContainerId, ItemStack cardItem) {
         super(pMenuType, pContainerId);
         this.cardItem = cardItem;
     }
+
+    public Direction getDirection(){
+        if (direction == -1)
+            return null;
+        return DIRS[direction];
+    }
     
+    public BlockEntity getBlockFaced(){
+        if (sourceContainer.equals(BlockPos.ZERO))
+            return null;
+        var dir = getDirection();
+        if (dir == null)
+            return null;
+        Level world = playerEntity.getLevel();
+        return world.getBlockEntity(sourceContainer.relative(dir));
+    }
+
+    public BlockState getBlockStateFaced(){
+        if (sourceContainer.equals(BlockPos.ZERO))
+            return null;
+        var dir = getDirection();
+        if (dir == null)
+            return null;
+        Level world = playerEntity.getLevel();
+        return world.getBlockState(sourceContainer.relative(dir));
+    }
 }

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardEnergyContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardEnergyContainer.java
@@ -25,9 +25,6 @@ import javax.annotation.Nullable;
 public class CardEnergyContainer extends AbstractCardContainer {
     public static final int SLOTS = 1;
     public CardItemHandler handler;
-    public Player playerEntity;
-    protected IItemHandler playerInventory;
-    public BlockPos sourceContainer = BlockPos.ZERO;
 
     protected CardEnergyContainer(@Nullable MenuType<?> pMenuType, int pContainerId, ItemStack cardItem) {
         super(pMenuType, pContainerId, cardItem);
@@ -36,6 +33,7 @@ public class CardEnergyContainer extends AbstractCardContainer {
     public CardEnergyContainer(int windowId, Inventory playerInventory, Player player, FriendlyByteBuf extraData) {
         this(windowId, playerInventory, player, extraData.readItem());
         this.direction = extraData.readByte();
+        this.sourceContainer = extraData.readBlockPos();
     }
 
     public CardEnergyContainer(int windowId, Inventory playerInventory, Player player, ItemStack cardItem) {

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardEnergyContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardEnergyContainer.java
@@ -9,7 +9,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
@@ -23,17 +22,15 @@ import net.minecraftforge.items.wrapper.InvWrapper;
 
 import javax.annotation.Nullable;
 
-public class CardEnergyContainer extends AbstractContainerMenu {
+public class CardEnergyContainer extends AbstractCardContainer {
     public static final int SLOTS = 1;
     public CardItemHandler handler;
-    public ItemStack cardItem;
     public Player playerEntity;
     protected IItemHandler playerInventory;
     public BlockPos sourceContainer = BlockPos.ZERO;
-    public byte direction = -1;
 
-    protected CardEnergyContainer(@Nullable MenuType<?> pMenuType, int pContainerId) {
-        super(pMenuType, pContainerId);
+    protected CardEnergyContainer(@Nullable MenuType<?> pMenuType, int pContainerId, ItemStack cardItem) {
+        super(pMenuType, pContainerId, cardItem);
     }
 
     public CardEnergyContainer(int windowId, Inventory playerInventory, Player player, FriendlyByteBuf extraData) {
@@ -42,11 +39,10 @@ public class CardEnergyContainer extends AbstractContainerMenu {
     }
 
     public CardEnergyContainer(int windowId, Inventory playerInventory, Player player, ItemStack cardItem) {
-        super(Registration.CardEnergy_Container.get(), windowId);
+        super(Registration.CardEnergy_Container.get(), windowId, cardItem);
         playerEntity = player;
         this.handler = CardEnergy.getInventory(cardItem);
         this.playerInventory = new InvWrapper(playerInventory);
-        this.cardItem = cardItem;
         if (handler != null) {
             //addSlotRange(handler, 0, 80, 5, 1, 18);
             addSlotRange(handler, 0, 153, 5, 1, 18);

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardFluidContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardFluidContainer.java
@@ -18,11 +18,10 @@ public class CardFluidContainer extends CardItemContainer {
     }
 
     public CardFluidContainer(int windowId, Inventory playerInventory, Player player, ItemStack cardItem) {
-        super(Registration.CardFluid_Container.get(), windowId);
+        super(Registration.CardFluid_Container.get(), windowId, cardItem);
         playerEntity = player;
         this.handler = BaseCard.getInventory(cardItem);
         this.playerInventory = new InvWrapper(playerInventory);
-        this.cardItem = cardItem;
         if (handler != null) {
             addSlotRange(handler, 0, 80, 5, 1, 18);
             addSlotRange(handler, 1, 153, 5, 1, 18);

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardFluidContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardFluidContainer.java
@@ -15,6 +15,7 @@ public class CardFluidContainer extends CardItemContainer {
     public CardFluidContainer(int windowId, Inventory playerInventory, Player player, FriendlyByteBuf extraData) {
         this(windowId, playerInventory, player, extraData.readItem());
         this.direction = extraData.readByte();
+        this.sourceContainer = extraData.readBlockPos();
     }
 
     public CardFluidContainer(int windowId, Inventory playerInventory, Player player, ItemStack cardItem) {

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardItemContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardItemContainer.java
@@ -34,9 +34,6 @@ public class CardItemContainer extends AbstractCardContainer {
     public static final int FILTERSLOTS = 15;
     public CardItemHandler handler;
     public FilterBasicHandler filterHandler;
-    public Player playerEntity;
-    protected IItemHandler playerInventory;
-    public BlockPos sourceContainer = BlockPos.ZERO;
 
     protected CardItemContainer(@Nullable MenuType<?> pMenuType, int pContainerId, ItemStack cardItem) {
         super(pMenuType, pContainerId, cardItem);
@@ -45,6 +42,7 @@ public class CardItemContainer extends AbstractCardContainer {
     public CardItemContainer(int windowId, Inventory playerInventory, Player player, FriendlyByteBuf extraData) {
         this(windowId, playerInventory, player, extraData.readItem());
         this.direction = extraData.readByte();
+        this.sourceContainer = extraData.readBlockPos();
     }
 
     public CardItemContainer(int windowId, Inventory playerInventory, Player player, ItemStack cardItem) {

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardItemContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardItemContainer.java
@@ -16,7 +16,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
@@ -30,19 +29,17 @@ import net.minecraftforge.items.wrapper.InvWrapper;
 
 import javax.annotation.Nullable;
 
-public class CardItemContainer extends AbstractContainerMenu {
+public class CardItemContainer extends AbstractCardContainer {
     public static final int SLOTS = 2;
     public static final int FILTERSLOTS = 15;
     public CardItemHandler handler;
     public FilterBasicHandler filterHandler;
-    public ItemStack cardItem;
     public Player playerEntity;
     protected IItemHandler playerInventory;
     public BlockPos sourceContainer = BlockPos.ZERO;
-    public byte direction = -1;
 
-    protected CardItemContainer(@Nullable MenuType<?> pMenuType, int pContainerId) {
-        super(pMenuType, pContainerId);
+    protected CardItemContainer(@Nullable MenuType<?> pMenuType, int pContainerId, ItemStack cardItem) {
+        super(pMenuType, pContainerId, cardItem);
     }
 
     public CardItemContainer(int windowId, Inventory playerInventory, Player player, FriendlyByteBuf extraData) {
@@ -51,11 +48,10 @@ public class CardItemContainer extends AbstractContainerMenu {
     }
 
     public CardItemContainer(int windowId, Inventory playerInventory, Player player, ItemStack cardItem) {
-        super(Registration.CardItem_Container.get(), windowId);
+        super(Registration.CardItem_Container.get(), windowId, cardItem);
         playerEntity = player;
         this.handler = BaseCard.getInventory(cardItem);
         this.playerInventory = new InvWrapper(playerInventory);
-        this.cardItem = cardItem;
         if (handler != null) {
             addSlotRange(handler, 0, 80, 5, 1, 18);
             addSlotRange(handler, 1, 153, 5, 1, 18);

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardRedstoneContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardRedstoneContainer.java
@@ -16,13 +16,11 @@ import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class CardRedstoneContainer extends AbstractCardContainer {
     public static final int SLOTS = 0;
-    public Player playerEntity;
-    private IItemHandler playerInventory;
-    public BlockPos sourceContainer = BlockPos.ZERO;
 
     public CardRedstoneContainer(int windowId, Inventory playerInventory, Player player, FriendlyByteBuf extraData) {
         this(windowId, playerInventory, player, extraData.readItem());
         this.direction = extraData.readByte();
+        this.sourceContainer = extraData.readBlockPos();
     }
 
     public CardRedstoneContainer(int windowId, Inventory playerInventory, Player player, ItemStack cardItem) {

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardRedstoneContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardRedstoneContainer.java
@@ -6,7 +6,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -15,13 +14,11 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
 
-public class CardRedstoneContainer extends AbstractContainerMenu {
+public class CardRedstoneContainer extends AbstractCardContainer {
     public static final int SLOTS = 0;
     public Player playerEntity;
     private IItemHandler playerInventory;
-    public ItemStack cardItem;
     public BlockPos sourceContainer = BlockPos.ZERO;
-    public byte direction = -1;
 
     public CardRedstoneContainer(int windowId, Inventory playerInventory, Player player, FriendlyByteBuf extraData) {
         this(windowId, playerInventory, player, extraData.readItem());
@@ -29,10 +26,9 @@ public class CardRedstoneContainer extends AbstractContainerMenu {
     }
 
     public CardRedstoneContainer(int windowId, Inventory playerInventory, Player player, ItemStack cardItem) {
-        super(Registration.CardRedstone_Container.get(), windowId);
+        super(Registration.CardRedstone_Container.get(), windowId, cardItem);
         playerEntity = player;
         this.playerInventory = new InvWrapper(playerInventory);
-        this.cardItem = cardItem;
         layoutPlayerInventorySlots(8, 84);
     }
 

--- a/src/main/java/com/direwolf20/laserio/common/containers/LaserNodeContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/LaserNodeContainer.java
@@ -8,6 +8,8 @@ import com.direwolf20.laserio.common.items.CardHolder;
 import com.direwolf20.laserio.common.items.cards.BaseCard;
 import com.direwolf20.laserio.common.items.upgrades.OverclockerNode;
 import com.direwolf20.laserio.setup.Registration;
+
+import net.minecraft.core.Direction;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -16,6 +18,7 @@ import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
@@ -39,6 +42,15 @@ public class LaserNodeContainer extends AbstractContainerMenu {
     // Tile can be null and shouldn't be used for accessing any data that needs to be up to date on both sides
     public LaserNodeBE tile;
     public byte side;
+
+    public static final Direction[] DIRS = {
+        Direction.DOWN,
+        Direction.UP,
+        Direction.NORTH,
+        Direction.SOUTH,
+        Direction.WEST,
+        Direction.EAST,
+    };
 
     public LaserNodeContainer(int windowId, Inventory playerInventory, Player player, FriendlyByteBuf extraData) {
         this((LaserNodeBE) playerInventory.player.level.getBlockEntity(extraData.readBlockPos()), windowId, extraData.readByte(), playerInventory, player, new LaserNodeItemHandler(SLOTS), ContainerLevelAccess.NULL, extraData.readItem());
@@ -323,5 +335,21 @@ public class LaserNodeContainer extends AbstractContainerMenu {
         // Hotbar
         topRow += 58;
         addSlotRange(playerInventory, 0, leftCol, topRow, 9, 18);
+    }
+
+    public Direction getDirection(){
+        if (side == -1)
+            return null;
+        return DIRS[side];
+    }
+
+    public BlockState getBlockStateFaced(){
+        if (tile == null)
+            return null;
+        var dir = getDirection();
+        if (dir == null)
+            return null;
+        var world = playerEntity.getLevel();
+        return world.getBlockState(tile.getBlockPos().relative(dir));
     }
 }

--- a/src/main/java/com/direwolf20/laserio/common/network/packets/PacketOpenCard.java
+++ b/src/main/java/com/direwolf20/laserio/common/network/packets/PacketOpenCard.java
@@ -18,6 +18,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.network.NetworkEvent;
 import net.minecraftforge.network.NetworkHooks;
 
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static com.direwolf20.laserio.common.items.cards.BaseCard.getInventory;
@@ -63,13 +64,15 @@ public class PacketOpenCard {
                 if (container instanceof LaserNodeContainer laserNodeContainer)
                     sideTemp = laserNodeContainer.side;
                 final byte side = sideTemp;
+                Consumer<FriendlyByteBuf> extraDataWriter = buf -> {
+                    buf.writeItem(itemStack);
+                    buf.writeByte(side);
+                    buf.writeBlockPos(msg.sourcePos);
+                };
                 if (itemStack.getItem() instanceof CardItem) {
                     if (!msg.hasShiftDown) {
                         NetworkHooks.openScreen(sender, new SimpleMenuProvider(
-                                (windowId, playerInventory, playerEntity) -> new CardItemContainer(windowId, playerInventory, sender, msg.sourcePos, itemStack, side), Component.translatable("")), (buf -> {
-                            buf.writeItem(itemStack);
-                            buf.writeByte(side);
-                        }));
+                                (windowId, playerInventory, playerEntity) -> new CardItemContainer(windowId, playerInventory, sender, msg.sourcePos, itemStack, side), Component.translatable("")), extraDataWriter);
                     } else {
                         ItemStack filterItem = handler.getStackInSlot(0);
                         if (filterItem.getItem() instanceof BaseFilter)
@@ -78,10 +81,7 @@ public class PacketOpenCard {
                 } else if (itemStack.getItem() instanceof CardFluid) {
                     if (!msg.hasShiftDown) {
                         NetworkHooks.openScreen(sender, new SimpleMenuProvider(
-                                (windowId, playerInventory, playerEntity) -> new CardFluidContainer(windowId, playerInventory, sender, msg.sourcePos, itemStack, side), Component.translatable("")), (buf -> {
-                            buf.writeItem(itemStack);
-                            buf.writeByte(side);
-                        }));
+                                (windowId, playerInventory, playerEntity) -> new CardFluidContainer(windowId, playerInventory, sender, msg.sourcePos, itemStack, side), Component.translatable("")), extraDataWriter);
                     } else {
                         ItemStack filterItem = handler.getStackInSlot(0);
                         if (filterItem.getItem() instanceof BaseFilter)
@@ -89,18 +89,11 @@ public class PacketOpenCard {
                     }
                 } else if (itemStack.getItem() instanceof CardEnergy) {
                     NetworkHooks.openScreen(sender, new SimpleMenuProvider(
-                            (windowId, playerInventory, playerEntity) -> new CardEnergyContainer(windowId, playerInventory, sender, msg.sourcePos, itemStack, side), Component.translatable("")), (buf -> {
-                        buf.writeItem(itemStack);
-                        buf.writeByte(side);
-                    }));
+                            (windowId, playerInventory, playerEntity) -> new CardEnergyContainer(windowId, playerInventory, sender, msg.sourcePos, itemStack, side), Component.translatable("")), extraDataWriter);
 
                 } else if (itemStack.getItem() instanceof CardRedstone) {
                     NetworkHooks.openScreen(sender, new SimpleMenuProvider(
-                            (windowId, playerInventory, playerEntity) -> new CardRedstoneContainer(windowId, playerInventory, sender, msg.sourcePos, itemStack, side), Component.translatable("")), (buf -> {
-                        buf.writeItem(itemStack);
-                        buf.writeByte(side);
-                    }));
-
+                            (windowId, playerInventory, playerEntity) -> new CardRedstoneContainer(windowId, playerInventory, sender, msg.sourcePos, itemStack, side), Component.translatable("")), extraDataWriter);
                 }
             });
 

--- a/src/main/java/com/direwolf20/laserio/datagen/LaserIOLanguageProvider.java
+++ b/src/main/java/com/direwolf20/laserio/datagen/LaserIOLanguageProvider.java
@@ -58,6 +58,7 @@ public class LaserIOLanguageProvider extends LanguageProvider {
         add("screen.laserio.south", "South");
         add("screen.laserio.west", "West");
         add("screen.laserio.east", "East");
+        add("screen.laserio.facing", "Facing");
 
         add("screen.laserio.extract", "Extract");
         add("screen.laserio.insert", "Insert");

--- a/src/main/java/com/direwolf20/laserio/util/CardRender.java
+++ b/src/main/java/com/direwolf20/laserio/util/CardRender.java
@@ -1,17 +1,21 @@
 package com.direwolf20.laserio.util;
 
 import com.direwolf20.laserio.client.blockentityrenders.LaserNodeBERender;
+import com.direwolf20.laserio.client.renderer.RenderUtils;
 import com.direwolf20.laserio.common.items.cards.BaseCard;
 import com.direwolf20.laserio.common.items.cards.CardRedstone;
 import com.mojang.math.Vector3f;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
 import static com.direwolf20.laserio.util.MiscTools.findOffset;
+
+import java.awt.*;
 
 public class CardRender {
     public Direction direction;
@@ -28,7 +32,7 @@ public class CardRender {
     public Vector3f endLaser;
     public float[] floatcolors;
 
-
+    
     public CardRender(Direction direction, int cardSlot, ItemStack card, BlockPos start, Level level, boolean enabled) {
         this.direction = direction;
         this.cardSlot = cardSlot;
@@ -37,23 +41,14 @@ public class CardRender {
         BlockState targetState = level.getBlockState(endBlock);
         VoxelShape voxelShape = targetState.getShape(level, endBlock);
         //System.out.println(voxelShape + ":" + voxelShape.getFaceShape(direction.getOpposite()));
-        if (((BaseCard) card.getItem()).getCardType() == BaseCard.CardType.ITEM) {
-            r = 0f;
-            g = 1f;
-            b = 0f;
-        } else if (((BaseCard) card.getItem()).getCardType() == BaseCard.CardType.FLUID) {
-            r = 0f;
-            g = 0f;
-            b = 1f;
-        } else if (((BaseCard) card.getItem()).getCardType() == BaseCard.CardType.ENERGY) {
-            r = 1f;
-            g = 1f;
-            b = 0f;
-        } else if (((BaseCard) card.getItem()).getCardType() == BaseCard.CardType.REDSTONE) {
-            r = 1f;
-            g = 0f;
-            b = 0f;
-        }
+        Item cardItem = card.getItem();
+        BaseCard baseCard = cardItem instanceof BaseCard ? (BaseCard) cardItem : null;
+        BaseCard.CardType cardType = baseCard != null ? baseCard.getCardType() : BaseCard.CardType.MISSING;
+        Color color = RenderUtils.getColor(cardType);
+        float[] cmps = color.getColorComponents(new float[3]);
+        r = cmps[0];
+        g = cmps[1];
+        b = cmps[2];
         if (!enabled) {
             r /= 4f;
             g /= 4f;

--- a/src/main/java/com/direwolf20/laserio/util/MiscTools.java
+++ b/src/main/java/com/direwolf20/laserio/util/MiscTools.java
@@ -1,6 +1,8 @@
 package com.direwolf20.laserio.util;
 
 import com.mojang.math.Vector3f;
+
+import net.minecraft.client.gui.components.Button;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -14,6 +16,12 @@ import java.util.List;
 public class MiscTools {
     public static boolean inBounds(int x, int y, int w, int h, double ox, double oy) {
         return ox >= x && ox <= x + w && oy >= y && oy <= y + h;
+    }
+
+    public static boolean inBounds(Button button, double ox, double oy) {
+        if (button == null)
+            return false;
+        return inBounds(button.x, button.y, button.getWidth(), button.getHeight(), ox, oy);
     }
 
     public static Vector3f findOffset(Direction direction, int slot, Vector3f[] offsets) {

--- a/src/main/java/com/direwolf20/laserio/util/MiscTools.java
+++ b/src/main/java/com/direwolf20/laserio/util/MiscTools.java
@@ -2,7 +2,7 @@ package com.direwolf20.laserio.util;
 
 import com.mojang.math.Vector3f;
 
-import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -18,10 +18,10 @@ public class MiscTools {
         return ox >= x && ox <= x + w && oy >= y && oy <= y + h;
     }
 
-    public static boolean inBounds(Button button, double ox, double oy) {
-        if (button == null)
+    public static boolean inBounds(AbstractWidget widget, double ox, double oy) {
+        if (widget == null)
             return false;
-        return inBounds(button.x, button.y, button.getWidth(), button.getHeight(), ox, oy);
+        return inBounds(widget.x, widget.y, widget.getWidth(), widget.getHeight(), ox, oy);
     }
 
     public static Vector3f findOffset(Direction direction, int slot, Vector3f[] offsets) {


### PR DESCRIPTION
This PR does two main things:
1. It shows the target block in the laser node for each side of laser node GUI:
![image](https://user-images.githubusercontent.com/17239590/188275567-1e3d1c38-9f8d-4452-afa8-97988994a635.png)
![image](https://user-images.githubusercontent.com/17239590/188275583-9c4e4147-98ff-4f49-9589-d7b10f220002.png)
![image](https://user-images.githubusercontent.com/17239590/188275592-e06a650d-755b-4484-83ee-617790f6c8d7.png)

2. When you go into the card GUI for a card that is in a laser node you get a side panel showing the side of the laser node and the block that is being faced with a background color set from the laser color for the card:
![image](https://user-images.githubusercontent.com/17239590/188275649-fa516aca-0c02-4aca-b11c-f77cae448a79.png)
![image](https://user-images.githubusercontent.com/17239590/188275655-0ae1981a-2a32-4fea-bd1b-3353a28c93ec.png)
![image](https://user-images.githubusercontent.com/17239590/188275723-8cb63754-a626-4b78-9018-d1e3ca578418.png)
![image](https://user-images.githubusercontent.com/17239590/188275734-f357c3bb-6f8b-4d99-87d7-fedd4e9621d5.png)

This is intended as a replacement for my previous PR: https://github.com/Direwolf20-MC/LaserIO/pull/120
