### PR TITLE
Fix energy card cloning, and cardholder displaying for energy cards

### DIFF
--- a/src/main/java/com/direwolf20/laserio/client/screens/CardEnergyScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/CardEnergyScreen.java
@@ -76,11 +76,6 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
     }
 
     @Override
-    protected void renderLabels(GuiGraphics guiGraphics, int mouseX, int mouseY) {
-
-    }
-
-    @Override
     public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
         validateHolder();
         this.renderBackground(guiGraphics);
@@ -462,6 +457,11 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
         return card.getItem() instanceof BaseCard && BaseCard.getNamedTransferMode(card) == BaseCard.TransferMode.EXTRACT;
     }
 
+    @Override
+    protected void renderLabels(GuiGraphics guiGraphics, int mouseX, int mouseY) {
+
+    }
+
     private boolean showExtractLimit() {
         return card.getItem() instanceof BaseCard && BaseCard.getNamedTransferMode(card) == BaseCard.TransferMode.EXTRACT;
     }
@@ -472,6 +472,11 @@ public class CardEnergyScreen extends AbstractContainerScreen<CardEnergyContaine
         int relX = (this.width - this.imageWidth) / 2;
         int relY = (this.height - this.imageHeight) / 2;
         guiGraphics.blit(GUI, relX, relY, 0, 0, this.imageWidth, this.imageHeight);
+        if (showCardHolderUI) {
+            ResourceLocation CardHolderGUI = new ResourceLocation(LaserIO.MODID, "textures/gui/cardholder_node.png");
+            RenderSystem.setShaderTexture(0, CardHolderGUI);
+            guiGraphics.blit(CardHolderGUI, getGuiLeft() - 100, getGuiTop() + 24, 0, 0, this.imageWidth, this.imageHeight);
+        }
     }
 
     @Override

--- a/src/main/java/com/direwolf20/laserio/common/containers/CardEnergyContainer.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/CardEnergyContainer.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.SlotItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
 

--- a/src/main/java/com/direwolf20/laserio/common/items/CardCloner.java
+++ b/src/main/java/com/direwolf20/laserio/common/items/CardCloner.java
@@ -86,16 +86,19 @@ public class CardCloner extends Item {
             toWrite.append(tooltipMaker(String.valueOf(channel), LaserNodeBERender.colors[channel].getRGB()));
             tooltip.add(toWrite);
 
-            toWrite = tooltipMaker("laserio.tooltip.item.card.Filter", ChatFormatting.GRAY.getColor());
-            ItemStack filterStack = getFilter(stack);
-            if (filterStack.isEmpty())
-                toWrite.append(tooltipMaker("laserio.tooltip.item.card.None", ChatFormatting.WHITE.getColor()));
-            else
-                toWrite.append(tooltipMaker("item.laserio." + filterStack.getItem(), ChatFormatting.DARK_AQUA.getColor()));
-            tooltip.add(toWrite);
+            if (!cardType.equals("card_energy")) {
+                toWrite = tooltipMaker("laserio.tooltip.item.card.Filter", ChatFormatting.GRAY.getColor());
+                ItemStack filterStack = getFilter(stack);
+                if (filterStack.isEmpty())
+                    toWrite.append(tooltipMaker("laserio.tooltip.item.card.None", ChatFormatting.WHITE.getColor()));
+                else
+                    toWrite.append(tooltipMaker("item.laserio." + filterStack.getItem(), ChatFormatting.DARK_AQUA.getColor()));
+                tooltip.add(toWrite);
+            }
 
+            var overclockerSlot = cardType.equals("card_energy")? 0 : 1;
             toWrite = tooltipMaker("laserio.tooltip.item.card.Overclockers", ChatFormatting.GRAY.getColor());
-            ItemStack overclockStack = getOverclocker(stack);
+            ItemStack overclockStack = getOverclocker(stack, overclockerSlot);
             if (overclockStack.isEmpty())
                 toWrite.append(tooltipMaker(String.valueOf(0), ChatFormatting.WHITE.getColor()));
             else
@@ -138,21 +141,21 @@ public class CardCloner extends Item {
         return filterStack;
     }
 
-    public static int getOverclockCount(ItemStack stack) {
+    public static int getOverclockCount(ItemStack stack, int slot) {
         CompoundTag compoundTag = getSettings(stack);
         ItemStackHandler itemStackHandler = new ItemStackHandler(CardItemContainer.SLOTS);
         itemStackHandler.deserializeNBT(compoundTag.getCompound("inv"));
-        ItemStack overclockStack = itemStackHandler.getStackInSlot(1);
+        ItemStack overclockStack = itemStackHandler.getStackInSlot(slot);
         if (overclockStack.isEmpty()) return 0;
 
         return overclockStack.getCount();
     }
 
-    public static ItemStack getOverclocker(ItemStack stack) {
+    public static ItemStack getOverclocker(ItemStack stack, int slot) {
         CompoundTag compoundTag = getSettings(stack);
         ItemStackHandler itemStackHandler = new ItemStackHandler(CardItemContainer.SLOTS);
         itemStackHandler.deserializeNBT(compoundTag.getCompound("inv"));
-        ItemStack overclockStack = itemStackHandler.getStackInSlot(1);
+        ItemStack overclockStack = itemStackHandler.getStackInSlot(slot);
         return overclockStack;
     }
 }

--- a/src/main/java/com/direwolf20/laserio/common/network/packets/PacketCopyPasteCard.java
+++ b/src/main/java/com/direwolf20/laserio/common/network/packets/PacketCopyPasteCard.java
@@ -151,11 +151,12 @@ public class PacketCopyPasteCard {
                     playSound(player, Holder.direct(SoundEvent.createVariableRangeEvent(new ResourceLocation(SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT.getLocation().toString()))));
                 } else {
                     if (slotStack.getItem().toString().equals(CardCloner.getItemType(clonerStack))) {
+                        var isEnergyCard = slotStack.getItem().toString().equals("card_energy");
                         CardItemHandler cardItemHandler = BaseCard.getInventory(slotStack);
-                        ItemStack filterNeeded = CardCloner.getFilter(clonerStack);
-                        ItemStack existingFilter = cardItemHandler.getStackInSlot(0);
-                        ItemStack overclockersNeeded = CardCloner.getOverclocker(clonerStack);
-                        ItemStack existingOverclockers = cardItemHandler.getStackInSlot(1);
+                        ItemStack filterNeeded = isEnergyCard ? ItemStack.EMPTY : CardCloner.getFilter(clonerStack);
+                        ItemStack existingFilter = isEnergyCard ? ItemStack.EMPTY : cardItemHandler.getStackInSlot(0);
+                        ItemStack overclockersNeeded = CardCloner.getOverclocker(clonerStack, isEnergyCard ? 0 : 1);
+                        ItemStack existingOverclockers = cardItemHandler.getStackInSlot(isEnergyCard ? 0 : 1);
                         boolean filterSatisfied = false;
                         boolean filterNeedsReturn = false;
                         boolean overclockSatisfied = false;
@@ -194,8 +195,8 @@ public class PacketCopyPasteCard {
                                 }
                                 getItemFromHolder(laserNodeContainer, filterNeeded, false);
                             }
-                            if (existingOverclockers.getCount() != overclockersNeeded.getCount()) { //If we need to work with Overclockers
-                                if (existingOverclockers.getCount() > overclockersNeeded.getCount()) { //If we have too many overclockers
+                            if (existingOverclockers.getCount() != overclockersNeeded.getCount()) { // If we need to work with Overclockers
+                                if (existingOverclockers.getCount() > overclockersNeeded.getCount()) { // If we have too many overclockers
                                     int amtReturn = existingOverclockers.getCount() - overclockersNeeded.getCount();
                                     ItemStack returnStack = new ItemStack(existingOverclockers.getItem(), amtReturn);
                                     boolean success = returnItemToholder(laserNodeContainer, returnStack, false);


### PR DESCRIPTION
Fixed #206 and #220.

This PR copys some of the code from `CardItemScreen` to `CardEnergyScreen` as well as the Card holder detection code from `CardItemContainer` to `CardEnergyContainer`

This also adds the special case for the `CardCloner` and the `PacketCopyPasteCard` to allow energy cards to render correctly in the tooltip, as well as copy the overclocker settings. (Energy cards only have 1 slot, because they don't have a filter)