### PR TITLE
Save block entity data to display ItemStacks for laser node GUI

### DIFF
--- a/src/main/java/com/direwolf20/laserio/client/screens/LaserNodeScreen.java
+++ b/src/main/java/com/direwolf20/laserio/client/screens/LaserNodeScreen.java
@@ -21,6 +21,7 @@ import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -29,6 +30,8 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.network.PacketDistributor;
 
@@ -121,8 +124,16 @@ public class LaserNodeScreen extends AbstractContainerScreen<LaserNodeContainer>
     }
 
     protected ItemStack getAdjacentBlock(Direction direction) {
-        BlockState blockState = container.playerEntity.level().getBlockState(this.container.tile.getBlockPos().relative(direction));
+        BlockPos blockPos = this.container.tile.getBlockPos().relative(direction);
+        Level level = this.container.playerEntity.level();
+        BlockState blockState = level.getBlockState(blockPos);
         ItemStack itemStack = blockState.getBlock().asItem().getDefaultInstance();
+        if (blockState.hasBlockEntity()) {
+            BlockEntity blockEntity = level.getBlockEntity(blockPos);
+            if (blockEntity != null) {
+                blockEntity.saveToItem(itemStack, level.registryAccess());
+            }
+        }
         return itemStack;
     }
 


### PR DESCRIPTION
This allows seeing the colors on an ender chest or the fluid in a tank for example

Before:
![Screenshot 2024-07-19 at 2 04 27 PM](https://github.com/user-attachments/assets/cdc65c8b-0865-45ef-86d1-cacb683e16f8)
After:
![Screenshot 2024-07-19 at 2 05 03 PM](https://github.com/user-attachments/assets/22138f6c-c9d7-4021-9a39-77fa6b40c18b)
