### PR TITLE
Fix node insert crash

### DIFF
--- a/src/main/java/com/direwolf20/laserio/common/blockentities/LaserNodeBE.java
+++ b/src/main/java/com/direwolf20/laserio/common/blockentities/LaserNodeBE.java
@@ -2306,7 +2306,7 @@ public class LaserNodeBE extends BaseLaserBE {
         for (Direction direction : Direction.values()) {
             IItemHandler h = level.getCapability(Capabilities.ItemHandler.BLOCK, getBlockPos(), direction);
             if (h == null) h = new ItemStackHandler(0);
-            for (int slot = 0; slot < h.getSlots(); slot++) {
+            for (int slot = 0; slot < LaserNodeContainer.CARDSLOTS; slot++) {
                 ItemStack card = h.getStackInSlot(slot);
                 if (!(card.getItem() instanceof BaseCard)) continue;
                 byte redstoneMode = BaseCard.getRedstoneMode(card);

--- a/src/main/java/com/direwolf20/laserio/common/containers/customhandler/LaserNodeItemHandler.java
+++ b/src/main/java/com/direwolf20/laserio/common/containers/customhandler/LaserNodeItemHandler.java
@@ -1,6 +1,7 @@
 package com.direwolf20.laserio.common.containers.customhandler;
 
 import com.direwolf20.laserio.common.blockentities.LaserNodeBE;
+import com.direwolf20.laserio.common.containers.LaserNodeContainer;
 import com.direwolf20.laserio.common.items.cards.BaseCard;
 import com.direwolf20.laserio.common.items.upgrades.OverclockerNode;
 import net.minecraft.core.NonNullList;
@@ -31,9 +32,9 @@ public class LaserNodeItemHandler extends ItemStackHandler {
 
     @Override
     public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-        if (slot == 9)
+        if (slot == LaserNodeContainer.CARDSLOTS)
             return stack.getItem() instanceof OverclockerNode;
-        return stack.getItem() instanceof BaseCard;
+        return slot < LaserNodeContainer.CARDSLOTS && stack.getItem() instanceof BaseCard;
     }
 
     @Nonnull


### PR DESCRIPTION
I have discovered a crash relating to inserting cards into a laserio node and decided to investigate and find a resolution for the issue.

The issue is that if you insert cards into a laserio node using any form of item transfer (either hopper, other mods, or using laserio itself), then the node will allow all 25 slots of its inventory (minus the one overclocker slot) to be filled with cards. To recreate just put a hopper/chute/etc on top of a node, and put 10 item cards in it.
Only the player should be allowed to insert into the cardholder slots of a node, not a machine, so to prevent this I edited the `LaserNodeItemHandler::isItemValid` method to disallow cards from being inserted into slots 9-25. This does not prevent players from interacting with the card holder slots themselves, just from cards being transferred by other means into those slots of the node.
The other issue that contributed to this crash is that `LaserNodeBE::populateRenderList` iterates through all 25 slots, not just the 9 card slots. This means that if cards end up in any of the other 15 slots (like through the bug above) that it will call `MiscTools::findOffset` with a slot parameter greater than 9, causing `offsets[slot]` to throw an `OutOfBoundsException`. This is what actually crashes the game. I considered also adding a check to the `MiscTools::findOffset` function to check that `slot` is in range of `offsets.length`, but decided to leave that out. There are other parts of the code that call that function, so it may be worth adding that check in the future to prevent other obscure crashes.